### PR TITLE
feat: add webpage headers to libraries

### DIFF
--- a/build/libraries/DLDUtils.js
+++ b/build/libraries/DLDUtils.js
@@ -2,10 +2,12 @@
  * @name DLDUtils
  * @description Allows plugins to move characters without the server's permission
  * @author TheLazySquid
- * @version 0.3.8
+ * @version 0.3.9
  * @downloadUrl https://raw.githubusercontent.com/Gimloader/client-plugins/refs/heads/main/build/libraries/DLDUtils.js
+ * @webpage https://gimloader.github.io/libraries/dldutils/
  * @needsLib Desync | https://raw.githubusercontent.com/Gimloader/client-plugins/refs/heads/main/build/libraries/Desync.js
  * @gamemode dontLookDown
+ * @changelog Added webpage link
  * @isLibrary true
  */
 

--- a/build/libraries/Desync.js
+++ b/build/libraries/Desync.js
@@ -2,9 +2,11 @@
  * @name Desync
  * @description Easily make simple settings menus
  * @author TheLazySquid
- * @version 0.1.2
+ * @version 0.1.3
  * @downloadUrl https://raw.githubusercontent.com/Gimloader/client-plugins/refs/heads/main/build/libraries/Desync.js
+ * @webpage https://gimloader.github.io/libraries/desync/
  * @gamemode 2d
+ * @changelog Added webpage link
  * @isLibrary true
  */
 

--- a/build/libraries/GamemodeDetector.js
+++ b/build/libraries/GamemodeDetector.js
@@ -2,8 +2,10 @@
  * @name GamemodeDetector
  * @description Detects which official 2d gamemode the player is in
  * @author TheLazySquid
- * @version 0.2.1
+ * @version 0.2.2
  * @downloadUrl https://raw.githubusercontent.com/Gimloader/client-plugins/refs/heads/main/build/libraries/GamemodeDetector.js
+ * @webpage https://gimloader.github.io/libraries/gamemodedetector/
+ * @changelog Added webpage link
  * @isLibrary true
  */
 

--- a/build/libraries/MobxUtils.js
+++ b/build/libraries/MobxUtils.js
@@ -2,8 +2,10 @@
  * @name MobxUtils
  * @description Some simple utilities for react injection with MobX
  * @author TheLazySquid
- * @version 0.3.1
+ * @version 0.3.2
  * @downloadUrl https://raw.githubusercontent.com/Gimloader/client-plugins/refs/heads/main/build/libraries/MobxUtils.js
+ * @webpage https://gimloader.github.io/libraries/mobxutils/
+ * @changelog Added webpage link
  * @isLibrary true
  */
 

--- a/libraries/DLDUtils/gimloader.config.js
+++ b/libraries/DLDUtils/gimloader.config.js
@@ -5,7 +5,9 @@ export default {
     description: "Allows plugins to move characters without the server's permission",
     author: "TheLazySquid",
     downloadUrl: "https://raw.githubusercontent.com/Gimloader/client-plugins/refs/heads/main/build/libraries/DLDUtils.js",
-    version: "0.3.8",
+    webpage: "https://gimloader.github.io/libraries/dldutils/",
+    version: "0.3.9",
+    changelog: ["Added webpage link"],
     libs: [
         "Desync | https://raw.githubusercontent.com/Gimloader/client-plugins/refs/heads/main/build/libraries/Desync.js"
     ],

--- a/libraries/Desync/gimloader.config.js
+++ b/libraries/Desync/gimloader.config.js
@@ -5,7 +5,9 @@ export default {
     description: "Easily make simple settings menus",
     author: "TheLazySquid",
     downloadUrl: "https://raw.githubusercontent.com/Gimloader/client-plugins/refs/heads/main/build/libraries/Desync.js",
-    version: "0.1.2",
+    webpage: "https://gimloader.github.io/libraries/desync/",
+    version: "0.1.3",
+    changelog: ["Added webpage link"],
     gamemodes: ["2d"],
     isLibrary: true
 };

--- a/libraries/GamemodeDetector/gimloader.config.js
+++ b/libraries/GamemodeDetector/gimloader.config.js
@@ -5,6 +5,8 @@ export default {
     description: "Detects which official 2d gamemode the player is in",
     author: "TheLazySquid",
     downloadUrl: "https://raw.githubusercontent.com/Gimloader/client-plugins/refs/heads/main/build/libraries/GamemodeDetector.js",
-    version: "0.2.1",
+    webpage: "https://gimloader.github.io/libraries/gamemodedetector/",
+    version: "0.2.2",
+    changelog: ["Added webpage link"],
     isLibrary: true
 };

--- a/libraries/MobxUtils/gimloader.config.js
+++ b/libraries/MobxUtils/gimloader.config.js
@@ -5,6 +5,8 @@ export default {
     description: "Some simple utilities for react injection with MobX",
     author: "TheLazySquid",
     downloadUrl: "https://raw.githubusercontent.com/Gimloader/client-plugins/refs/heads/main/build/libraries/MobxUtils.js",
-    version: "0.3.1",
+    webpage: "https://gimloader.github.io/libraries/mobxutils/",
+    version: "0.3.2",
+    changelog: ["Added webpage link"],
     isLibrary: true
 };


### PR DESCRIPTION
I'm assuming that every update is supposed to have a `changelog` header, but these might not be necessarily